### PR TITLE
Guarantee the redis service will be launched in a manager node.

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,6 +20,8 @@ services:
         image: redis
         deploy:
             replicas: 1
+            placement:
+                constraints: [node.role == manager]
 
 secrets:
     db_password:


### PR DESCRIPTION
Hi Luke!

First, thank you for sharing your project. It helped me demonstrate some aspects of our cluster work as expected.

One thing I believe could be improved is adding a constraint for the redis service to run only in manager nodes, allowing you to scale-down the # of worker nodes without worrying about losing the current counter.

If you think it's not interesting or just don't like the idea, feel free to reject this PR. No worries :-)